### PR TITLE
add executable to ~/.local/bin/

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -20,6 +20,11 @@ clear
 echo getting main.py
 curl -o main.py "https://raw.githubusercontent.com/metalfoxdev/Raindrop/v$version/main.py"
 clear
+echo creating executable
+echo "python3 /home/$usrname/.local/share/RaindropWeather/main.py" >> raindrop
+chmod u+x raindrop
+mv raindrop /home/$usrname/.local/bin/
+clear
 echo writing desktop file
 echo "[Desktop Entry]" >> raindrop.desktop
 echo "Version=$version" >> raindrop.desktop


### PR DESCRIPTION
fixes #9 

creates an executable in `~/.local/bin/`, so that after installation you can run the program by calling `raindrop`.

todo: `~/.local/bin` might not be in PATH. different shells handle that differently, so probably best to mention that as a post-installation step.